### PR TITLE
Ocultar scrollbars en el banner

### DIFF
--- a/app/styles/banner.scss
+++ b/app/styles/banner.scss
@@ -1,5 +1,9 @@
 @import "main.scss";
 
+body {
+  overflow: hidden;
+}
+
 .container-fluid, .row-full, .col-full {
   height: 100%;
 }


### PR DESCRIPTION
Ocultar scrollbars en el banner, para probar sirven pero quedan mal a pantalla completa.

No probé este cambio porque no tengo las dependencias necesarias en mi PC (npm/bower/etc).
